### PR TITLE
Added useNativeDriver to animated.timing

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ class FlipComponent extends Component {
           toValue: 1,
           duration: this.props.scaleDuration,
           easing: Easing.linear,
+          useNativeDriver: true,
         },
       ),
       Animated.timing(
@@ -71,6 +72,7 @@ class FlipComponent extends Component {
           toValue,
           duration: this.props.rotateDuration,
           easing: Easing.linear,
+          useNativeDriver: true,
         },
       ),
       Animated.timing(
@@ -79,6 +81,7 @@ class FlipComponent extends Component {
           toValue: 0,
           duration: this.props.scaleDuration,
           easing: Easing.linear,
+          useNativeDriver: true,
         },
       ),
     ]).start();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flip-component",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Double-sided React component that flips 180 degrees",
   "author": "Phil Mok",
   "main": "index.js",


### PR DESCRIPTION
Fixed an error message in the logs regarding useNativeDriver is not specified. 

Related to: https://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated

Error:
`Animated: `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false`
at node_modules/react-native/Libraries/Animated/NativeAnimatedHelper.js:347:4 in shouldUseNativeDriver
at node_modules/react-native/Libraries/Animated/animations/TimingAnimation.js:75:49 in constructor
at node_modules/react-native/Libraries/Animated/AnimatedImplementation.js:206:26 in start
at node_modules/react-native/Libraries/Animated/AnimatedImplementation.js:213:13 in start
at node_modules/react-native/Libraries/Animated/AnimatedImplementation.js:297:8 in onComplete
at node_modules/react-native/Libraries/Animated/nodes/AnimatedValue.js:226:28 in animation.start$argument_2
at node_modules/react-native/Libraries/Animated/animations/Animation.js:59:18 in __debouncedOnEnd
at node_modules/react-native/Libraries/Animated/animations/TimingAnimation.js:142:6 in onUpdate
`

To Test:
- Add a flip component, set front and back, click flip button and it should not throw a message in the console anymore.